### PR TITLE
minified js wrapping: additional semicolon

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,7 +33,7 @@ export const alphabet = [
   "__dz",
 ];
 
-export const umdFooter = `if (typeof module.exports == "object" && typeof exports == "object") {
+export const umdFooter = `;if (typeof module.exports == "object" && typeof exports == "object") {
   var __cp = (to, from, except, desc) => {
     if ((from && typeof from === "object") || typeof from === "function") {
       for (let key of Object.getOwnPropertyNames(from)) {


### PR DESCRIPTION
Resolves #2 
This semicolon saves the code in case a minified module is wrapped.